### PR TITLE
Add models and services for student deck data.

### DIFF
--- a/app/controllers/api/cards_controller.rb
+++ b/app/controllers/api/cards_controller.rb
@@ -11,6 +11,11 @@ class Api::CardsController < ApplicationController
   end
 
   def create
+    if @card.save
+      render json: @card, status: 201, location: [:api, @card]
+    else
+      render json: { errors: @card.errors }, status: 422
+    end
   end
 
   def update
@@ -24,6 +29,6 @@ class Api::CardsController < ApplicationController
   private
 
   def card_params
-    params.require(:card).permit(:id, :front, :back, :easiness, :consecutive_correct_answers, :next_due_date)
+    params.require(:card).permit(:id, :deck_id, :front, :back, :easiness, :consecutive_correct_answers, :next_due_date)
   end
 end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,3 +1,4 @@
 class Card < ApplicationRecord
   belongs_to :deck
+  has_many :card_student_relationships
 end

--- a/app/models/card_student_relationship.rb
+++ b/app/models/card_student_relationship.rb
@@ -1,0 +1,5 @@
+class CardStudentRelationship < ApplicationRecord
+  belongs_to :student
+  belongs_to :card
+  belongs_to :deck
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,8 +1,8 @@
 class Course < ApplicationRecord
   belongs_to :educator
 
-  has_many :course_user_relationships, dependent: :destroy
-  has_many :students, through: :course_user_relationships, source: :user
+  has_many :course_student_relationships, dependent: :destroy
+  has_many :students, through: :course_student_relationships
 
   has_many :decks
 end

--- a/app/models/course_student_relationship.rb
+++ b/app/models/course_student_relationship.rb
@@ -1,0 +1,4 @@
+class CourseStudentRelationship < ApplicationRecord
+  belongs_to :student
+  belongs_to :course
+end

--- a/app/models/course_user_relationship.rb
+++ b/app/models/course_user_relationship.rb
@@ -1,4 +1,0 @@
-class CourseUserRelationship < ApplicationRecord
-  belongs_to :user
-  belongs_to :course
-end

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -1,4 +1,5 @@
 class Deck < ApplicationRecord
   belongs_to :course
   has_many :cards
+  has_many :card_student_relationships
 end

--- a/app/models/educator_student_relationship.rb
+++ b/app/models/educator_student_relationship.rb
@@ -1,4 +1,4 @@
 class EducatorStudentRelationship < ApplicationRecord
-  belongs_to :student, class_name: "User"
-  belongs_to :educator, class_name: "User"
+  belongs_to :student
+  belongs_to :educator
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -2,6 +2,8 @@ class Student < User
   has_many :educator_student_relationships, foreign_key: :student_id
   has_many :educators, through: :educator_student_relationships, source: :educator
 
-  has_many :course_user_relationships, foreign_key: :user_id, dependent: :destroy
-  has_many :courses, through: :course_user_relationships
+  has_many :course_student_relationships, foreign_key: :student_id, dependent: :destroy
+  has_many :courses, through: :course_student_relationships
+
+  has_many :card_student_relationships
 end

--- a/app/services/courses/populate_student_course_service.rb
+++ b/app/services/courses/populate_student_course_service.rb
@@ -1,0 +1,25 @@
+module Courses
+  class PopulateStudentCourseService
+    attr_accessor :course
+    attr_accessor :student
+
+    def initialize(course, student)
+      @course = course
+      @student = student
+    end
+
+    def execute
+      course.decks.each do |deck|
+        generate_card_relationships_for_deck deck
+      end
+    end
+
+    private
+
+    def generate_card_relationships_for_deck deck
+      deck.cards.find_each do |card|
+        CardStudentRelationship.create(card: card, student: student, deck: deck)
+      end
+    end
+  end
+end

--- a/app/services/students/follow_course_service.rb
+++ b/app/services/students/follow_course_service.rb
@@ -9,7 +9,8 @@ module Students
     end
 
     def execute
-      CourseUserRelationship.create(user: student, course: course)
+      CourseStudentRelationship.create(student: student, course: course)
+      Courses::PopulateStudentCourseService.new(course, student).execute
     end
   end
 end

--- a/db/migrate/20181014202710_create_card_user_relationships.rb
+++ b/db/migrate/20181014202710_create_card_user_relationships.rb
@@ -1,0 +1,19 @@
+class CreateCardUserRelationships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :card_user_relationships do |t|
+      t.references :card, foreign_key: true
+      t.references :user, foreign_key: true
+      t.references :deck, foreign_key: true
+      t.float :easiness
+      t.text :front
+      t.text :back
+      t.integer :consecutive_correct_answers
+      t.datetime :next_due_date
+
+      t.timestamps
+    end
+
+    add_index :card_user_relationships, [:card_id, :user_id], name: "card_user_index"
+    add_index :card_user_relationships, [:card_id, :deck_id], name: "card_deck_index"
+  end
+end

--- a/db/migrate/20181014203205_remove_front_and_back_from_card_user_relationships.rb
+++ b/db/migrate/20181014203205_remove_front_and_back_from_card_user_relationships.rb
@@ -1,0 +1,6 @@
+class RemoveFrontAndBackFromCardUserRelationships < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :card_user_relationships, :front, :text
+    remove_column :card_user_relationships, :back, :text
+  end
+end

--- a/db/migrate/20181019222608_rename_user_relationship_tables.rb
+++ b/db/migrate/20181019222608_rename_user_relationship_tables.rb
@@ -1,0 +1,6 @@
+class RenameUserRelationshipTables < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :course_user_relationships, :course_student_relationships
+    rename_table :card_user_relationships, :card_student_relationships
+  end
+end

--- a/db/migrate/20181019222757_rename_user_id_in_relationship_tables.rb
+++ b/db/migrate/20181019222757_rename_user_id_in_relationship_tables.rb
@@ -1,0 +1,6 @@
+class RenameUserIdInRelationshipTables < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :card_student_relationships, :user_id, :student_id
+    rename_column :course_student_relationships, :user_id, :student_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_04_225732) do
+ActiveRecord::Schema.define(version: 2018_10_19_222757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "card_student_relationships", force: :cascade do |t|
+    t.bigint "card_id"
+    t.bigint "student_id"
+    t.bigint "deck_id"
+    t.float "easiness"
+    t.integer "consecutive_correct_answers"
+    t.datetime "next_due_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["card_id", "deck_id"], name: "card_deck_index"
+    t.index ["card_id", "student_id"], name: "card_user_index"
+    t.index ["card_id"], name: "index_card_student_relationships_on_card_id"
+    t.index ["deck_id"], name: "index_card_student_relationships_on_deck_id"
+    t.index ["student_id"], name: "index_card_student_relationships_on_student_id"
+  end
 
   create_table "cards", force: :cascade do |t|
     t.bigint "deck_id"
@@ -27,13 +43,13 @@ ActiveRecord::Schema.define(version: 2018_10_04_225732) do
     t.index ["deck_id"], name: "index_cards_on_deck_id"
   end
 
-  create_table "course_user_relationships", force: :cascade do |t|
-    t.bigint "user_id"
+  create_table "course_student_relationships", force: :cascade do |t|
+    t.bigint "student_id"
     t.bigint "course_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["course_id"], name: "index_course_user_relationships_on_course_id"
-    t.index ["user_id"], name: "index_course_user_relationships_on_user_id"
+    t.index ["course_id"], name: "index_course_student_relationships_on_course_id"
+    t.index ["student_id"], name: "index_course_student_relationships_on_student_id"
   end
 
   create_table "courses", force: :cascade do |t|
@@ -75,8 +91,11 @@ ActiveRecord::Schema.define(version: 2018_10_04_225732) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "card_student_relationships", "cards"
+  add_foreign_key "card_student_relationships", "decks"
+  add_foreign_key "card_student_relationships", "users", column: "student_id"
   add_foreign_key "cards", "decks"
-  add_foreign_key "course_user_relationships", "courses"
-  add_foreign_key "course_user_relationships", "users"
+  add_foreign_key "course_student_relationships", "courses"
+  add_foreign_key "course_student_relationships", "users", column: "student_id"
   add_foreign_key "decks", "courses"
 end

--- a/spec/controllers/api/cards_controller_spec.rb
+++ b/spec/controllers/api/cards_controller_spec.rb
@@ -28,6 +28,62 @@ RSpec.describe Api::CardsController, type: :controller do
     end
   end
 
+  describe "POST #create" do
+    RSpec.shared_examples_for "a failed card creation" do
+      it "doesn't create the card" do
+        card = attributes_for(:card)
+        deck = create(:deck)
+
+        expect {
+          post :create, params: { card: card, deck_id: deck.id }
+        }.to_not change(Card, :count)
+      end
+
+      it "returns a 403 status" do
+        post :create, params: { card: attributes_for(:card) }
+
+        expect(response.status).to eq 403
+      end
+    end
+
+    context "when signed in as an educator" do
+      context "who owns the deck" do
+        it "creates the card when the educator owns the deck" do
+          educator = sign_in_educator
+          course = create(:course, educator: educator)
+          deck = create(:deck, course: course)
+          card = attributes_for(:card, deck_id: deck.id)
+
+          expect {
+            post :create, params: { card: card }
+          }.to change(Card, :count).by(1)
+        end
+      end
+
+      it "doesn't create the card when the educator doesn't own the deck" do
+        deck = create(:deck)
+        card = attributes_for(:card, deck_id: deck.id)
+        sign_in_educator
+
+        expect {
+          post :create, params: { card: card }
+        }.to_not change(Card, :count)
+      end
+    end
+
+    context "when not signed in" do
+      it_behaves_like "a failed card creation"
+    end
+
+    context "when signed in as a student" do
+      before do
+        sign_in_student
+      end
+
+      it_behaves_like "a failed card creation"
+    end
+  end
+
   describe "PATCH #update" do
     context "for a successful update" do
       it "updates then renders the card" do

--- a/spec/factories/card_student_relationships.rb
+++ b/spec/factories/card_student_relationships.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :card_student_relationship do
+    easiness { 0 }
+    consecutive_correct_answers { 0 }
+    next_due_date { DateTime.now + 1.day }
+    card
+    student
+    deck
+  end
+end

--- a/spec/factories/course_student_relationships.rb
+++ b/spec/factories/course_student_relationships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :course_student_relationship do
+    student
+    course
+  end
+end

--- a/spec/factories/course_user_relationships.rb
+++ b/spec/factories/course_user_relationships.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :course_user_relationship do
-    user
-    course
-  end
-end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    type { "User" }
+    sequence(:email) { |n| "user-#{n}@example.com" }
+    password { "password" }
+  end
+end

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -7,5 +7,11 @@ RSpec.describe Card, type: :model do
       card = create(:card, deck: deck)
       expect(card.deck).to eq deck
     end
+
+    it "can have card_student_relationships" do
+      card = create(:card)
+      card_student_relationship = create(:card_student_relationship, card: card)
+      expect(card.card_student_relationships).to include card_student_relationship
+    end
   end
 end

--- a/spec/models/card_student_relationship_spec.rb
+++ b/spec/models/card_student_relationship_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe CardStudentRelationship, type: :model do
+  describe "associations" do
+    it "can belong to a student" do
+      card_student_relationship = create(:card_student_relationship, student: create(:student))
+      expect(card_student_relationship.student).to be_instance_of(Student)
+    end
+
+    it "can belong to a deck" do
+      card_student_relationship = create(:card_student_relationship)
+      expect(card_student_relationship.deck).to be_instance_of(Deck)
+    end
+
+    it "can belong to a card" do
+      card_student_relationship = create(:card_student_relationship)
+      expect(card_student_relationship.card).to be_instance_of(Card)
+    end
+  end
+end

--- a/spec/models/course_student_relationship_spec.rb
+++ b/spec/models/course_student_relationship_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe CourseStudentRelationship, type: :model do
+end

--- a/spec/models/course_user_relationship_spec.rb
+++ b/spec/models/course_user_relationship_spec.rb
@@ -1,4 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe CourseUserRelationship, type: :model do
-end

--- a/spec/models/deck_spec.rb
+++ b/spec/models/deck_spec.rb
@@ -14,5 +14,11 @@ RSpec.describe Deck, type: :model do
         deck.cards.create(attributes_for(:card))
       }.to change(deck.cards, :count).by 1
     end
+
+    it "can have card_student_relationships" do
+      deck = create(:deck)
+      card_student_relationship = create(:card_student_relationship, deck: deck)
+      expect(deck.card_student_relationships).to include card_student_relationship
+    end
   end
 end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -10,5 +10,12 @@ RSpec.describe Student, type: :model do
 
       expect(student.educators).to include educator
     end
+
+    it "can have card_student_relationships" do
+      student = create(:student)
+      # expect(student).to be_instance_of(Student)
+      card_student_relationship = create(:card_student_relationship, student: student)
+      expect(student.card_student_relationships).to include card_student_relationship
+    end
   end
 end

--- a/spec/services/courses/populate_student_course_service_spec.rb
+++ b/spec/services/courses/populate_student_course_service_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Courses::PopulateStudentCourseService, type: :service do
+  it "creates the correct # of user card relationships" do
+    count = 2
+    course, deck = create_course_with_cards count
+    student = create(:student)
+    service = Courses::PopulateStudentCourseService.new(course, student)
+    expect {
+      service.execute
+      course.reload
+    }.to change(CardStudentRelationship, :count).by count
+  end
+
+  it "assigns card_user_relationships to the correct student and deck" do
+    course, deck = create_course_with_cards 2
+    student = create(:student)
+
+    service = Courses::PopulateStudentCourseService.new(course, student)
+    service.execute
+
+    CardStudentRelationship.all.each do |relationship|
+      expect(relationship.student).to eq student
+      expect(relationship.deck).to eq deck
+    end
+  end
+
+  def create_course_with_cards(count = 4)
+    course = create(:course)
+    student = create(:student)
+    deck = create(:deck, course: course)
+    count.times { create(:card, deck: deck) }
+    [course, deck]
+  end
+end

--- a/spec/services/students/follow_course_service_spec.rb
+++ b/spec/services/students/follow_course_service_spec.rb
@@ -9,4 +9,14 @@ RSpec.describe Students::FollowCourseService, type: :service do
       service.execute
     }.to change(course.students, :count).by 1
   end
+
+  it "populates student cards" do
+    course = create(:course)
+    student = create(:student)
+
+    expect_any_instance_of(Courses::PopulateStudentCourseService).to receive(:execute)
+
+    service = Students::FollowCourseService.new(student, course)
+    service.execute
+  end
 end


### PR DESCRIPTION
The card student relationship model enables students to
store their performance data by card. The
Courses::PopulateStudentCourseService creates these
mirrored student decks when the student follows a course.

Add the card_user_relationship model.

Also adds a spec and factory.

Add specs for card user relationships.

Also adds a user factory.

WIP: Begin to add card user relationship associations.

I will be renaming relationship tables/columns to use student instead
of user, in order to clarify the association picture.

Refactor x_user_relationships into x_student_relationships.

This refactor clarifies the affected models' use. It restricts
Educators from subscribing to courses, which was not planned
anyway.

Add the Courses::PopulateStudentCourseService.

This service creates card_student_relationships for each card
in a course's decks. These relationships give students a way to
track their performance.

Populate student decks when a student follows a course.

Also add a create method to the cards controller.