### PR TITLE
Serve the react app from non-api routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,8 @@ class ApplicationController < ActionController::Base
       format.html { redirect_to root_url, alert: exception.message }
     end
   end
+
+  def fallback_index_html
+    render :file => 'public/index.html'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,7 @@ Rails.application.routes.draw do
     resources :course_student_relationships, only: [:index, :create, :destroy]
   end
 
-  # root to: "home#index"
+  get '*path', to: "application#fallback_index_html", constraints: ->(request) do
+    !request.xhr? && request.format.html?
+  end
 end


### PR DESCRIPTION
With this PR, we serve the React app from more than just the "/" path. This way, users can enter the app from various routes.